### PR TITLE
Create an item

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -9,7 +9,23 @@ class Api::V1::ItemsController < ApplicationController
     render json: ItemSerializer.item_show(@item)
   end
 
+  def create
+    item = Item.new(item_params)
+
+    if item.save
+      render json: ItemSerializer.item_show(item)
+    else
+      render json: ErrorSerializer.creation_errors(item), status: 422
+    end
+  end
+
+  private
+
   def get_item
     @item = Item.find(params[:id])
+  end
+
+  def item_params
+    params.permit(:name, :description, :unit_price, :merchant_id)
   end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::ItemsController < ApplicationController
     if item.save
       render json: ItemSerializer.item_show(item)
     else
-      render json: ErrorSerializer.creation_errors(item), status: 422
+      render json: ItemErrorSerializer.creation_errors(item), status: 422
     end
   end
 

--- a/app/serializers/api/v1/items_controller/error_serializer.rb
+++ b/app/serializers/api/v1/items_controller/error_serializer.rb
@@ -1,0 +1,8 @@
+class Api::V1::ItemsController::ErrorSerializer
+  def self.creation_errors(item)
+    {
+      message: 'your query could not be completed',
+      errors: item.errors.full_messages
+    }
+  end
+end

--- a/app/serializers/api/v1/items_controller/item_error_serializer.rb
+++ b/app/serializers/api/v1/items_controller/item_error_serializer.rb
@@ -1,4 +1,4 @@
-class Api::V1::ItemsController::ErrorSerializer
+class Api::V1::ItemsController::ItemErrorSerializer
   def self.creation_errors(item)
     {
       message: 'your query could not be completed',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :merchants, only: [:index, :show]
-      resources :items, only: [:index, :show]
+      resources :items, only: [:index, :show, :create]
     end
   end
 end

--- a/spec/requests/api/v1/items/create_spec.rb
+++ b/spec/requests/api/v1/items/create_spec.rb
@@ -70,6 +70,25 @@ RSpec.describe 'Creating an Item' do
       expect(full_response).to have_key :errors
       expect(full_response[:errors]).to be_a Array
       expect(full_response[:errors]).to be_all String
+      expect(full_response[:errors]).to include("Description can't be blank")
+      expect(full_response[:errors]).to include("Unit price can't be blank")
+      expect(full_response[:errors]).to include("Unit price is not a number")
+      expect(full_response[:errors]).to include("Merchant must exist")
+    end
+
+    it 'ignores any attributes that are not allowed' do
+      @item_params[:food] = Faker::Food.dish
+      @item_params[:hacker_encryption] = Faker::String.random
+
+      post '/api/v1/items', params: @item_params
+
+      expect(response).to be_successful
+
+      expect(@item).to_not respond_to(:food)
+      expect(@item_response).to_not have_key(:food)
+
+      expect(@item).to_not respond_to(:hacker_encryption)
+      expect(@item_response).to_not have_key(:hacker_encryption)
     end
   end
 end

--- a/spec/requests/api/v1/items/create_spec.rb
+++ b/spec/requests/api/v1/items/create_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'Creating an Item' do
+  before :each do
+    @item_params = {
+      'name': 'Tech Deck',
+      'description': 'Use your fingers to skateboard!',
+      'unit_price': 15.99,
+      'merchant_id': Merchant.ids.sample
+    }
+    post '/api/v1/items', params: JSON.generate(:item, @item_params)
+
+    full_response = JSON.parse(response.body, symbolize_names: true)
+
+    @item = Item.last
+    @item_response = full_response[:data]
+  end
+
+  context 'when valid data is entered' do
+    it 'returns a JSON response with item details' do
+      expect(response).to be_successful
+      expect(@item_response).to have_key :id
+      expect(@item_response[:id]).to eq(@item.id)
+
+      expect(@item_response).to have_key :type
+      expect(@item_response[:type]).to eq('item')
+
+      expect(@item_response).to have_key :attributes
+      expect(@item_response[:attributes]).to be_a Hash
+
+      expect(@item_response[:attributes]).to have_key :name
+      expect(@item_response[:attributes][:name]).to eq(@item_params[:name])
+
+      expect(@item_response[:attributes]).to have_key :description
+      expect(@item_response[:attributes][:description]).to eq(@item_params[:description])
+
+      expect(@item_response[:attributes]).to have_key :unit_price
+      expect(@item_response[:attributes][:unit_price]).to eq(@item_params[:unit_price])
+
+      expect(@item_response[:attributes]).to have_key :merchant_id
+      expect(@item_response[:attributes][:merchant_id]).to eq(@item_params[:merchant_id])
+    end
+
+    it 'creates an item' do
+      expect(@item.name).to eq(@item_params[:name])
+      expect(@item.description).to eq(@item_params[:description])
+      expect(@item.unit_price).to eq(@item_params[:unit_price])
+      expect(@item.merchant_id).to eq(@item_params[:merchant_id])
+    end
+  end
+
+  context 'when invalid data is entered' do
+    it 'returns an error if any attributes are missing' do
+      item_params = {
+        'name': 'Tech Deck'
+      }
+
+      post '/api/v1/items', params: item_params
+
+      full_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(422)
+
+      expect(full_response).to have_key :message
+      expect(full_response[:message]).to eq('your query could not be completed')
+
+      expect(full_response).to have_ket :errors
+      expect(full_response[:errors]).to be_a Array
+      expect(full_response[:errors]).to be_all String
+    end
+  end
+end

--- a/spec/requests/api/v1/items/create_spec.rb
+++ b/spec/requests/api/v1/items/create_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.describe 'Creating an Item' do
   before :each do
+    create_list(:merchant, 5)
+
     @item_params = {
-      'name': 'Tech Deck',
-      'description': 'Use your fingers to skateboard!',
-      'unit_price': 15.99,
-      'merchant_id': Merchant.ids.sample
+      name: 'Tech Deck',
+      description: 'Use your fingers to skateboard!',
+      unit_price: 15.99,
+      merchant_id: Merchant.ids.sample
     }
-    post '/api/v1/items', params: JSON.generate(:item, @item_params)
+    post '/api/v1/items', params: @item_params
 
     full_response = JSON.parse(response.body, symbolize_names: true)
 
@@ -20,7 +22,7 @@ RSpec.describe 'Creating an Item' do
     it 'returns a JSON response with item details' do
       expect(response).to be_successful
       expect(@item_response).to have_key :id
-      expect(@item_response[:id]).to eq(@item.id)
+      expect(@item_response[:id]).to eq(@item.id.to_s)
 
       expect(@item_response).to have_key :type
       expect(@item_response[:type]).to eq('item')
@@ -52,10 +54,10 @@ RSpec.describe 'Creating an Item' do
   context 'when invalid data is entered' do
     it 'returns an error if any attributes are missing' do
       item_params = {
-        'name': 'Tech Deck'
+        name: 'Tech Deck'
       }
 
-      post '/api/v1/items', params: item_params
+      post '/api/v1/items', params: item_params 
 
       full_response = JSON.parse(response.body, symbolize_names: true)
 
@@ -65,7 +67,7 @@ RSpec.describe 'Creating an Item' do
       expect(full_response).to have_key :message
       expect(full_response[:message]).to eq('your query could not be completed')
 
-      expect(full_response).to have_ket :errors
+      expect(full_response).to have_key :errors
       expect(full_response[:errors]).to be_a Array
       expect(full_response[:errors]).to be_all String
     end


### PR DESCRIPTION
Added a `create` method to the `API::V1::ItemsController` which uses a `ItemSerializer` and `ItemErrorSerializer` to validate, and then create an Item.