### PR TITLE
Merchant show sad path

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::MerchantsController < ApplicationController
   before_action :get_merchant, only: [:show]
+  rescue_from ::ActiveRecord::RecordNotFound, with: :merchant_not_found
 
   def index
     render json: MerchantSerializer.merchants_index(Merchant.all)
@@ -13,5 +14,9 @@ class Api::V1::MerchantsController < ApplicationController
 
   def get_merchant
     @merchant = Merchant.find(params[:id])
+  end
+
+  def merchant_not_found
+    render json: MerchantErrorSerializer.no_merchant(params[:id]), status: 404
   end
 end

--- a/app/serializers/api/v1/application_error_serializer.rb
+++ b/app/serializers/api/v1/application_error_serializer.rb
@@ -1,0 +1,8 @@
+class Api::V1::ApplicationErrorSerializer
+  def self.base_error_with(error_messages)
+    {
+      message: 'your query could not be completed',
+      errors: error_messages
+    }
+  end
+end

--- a/app/serializers/api/v1/items_controller/item_error_serializer.rb
+++ b/app/serializers/api/v1/items_controller/item_error_serializer.rb
@@ -1,8 +1,5 @@
-class Api::V1::ItemsController::ItemErrorSerializer
+class Api::V1::ItemsController::ItemErrorSerializer < Api::V1::ApplicationErrorSerializer
   def self.creation_errors(item)
-    {
-      message: 'your query could not be completed',
-      errors: item.errors.full_messages
-    }
+    base_error_with(item.errors.full_messages)
   end
 end

--- a/app/serializers/api/v1/merchants_controller/merchant_error_serializer.rb
+++ b/app/serializers/api/v1/merchants_controller/merchant_error_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::MerchantsController::MerchantErrorSerializer < Api::V1::ApplicationErrorSerializer 
+  def self.no_merchant(id)
+    base_error_with(["no merchant found with an ID of #{id}"])
+  end
+end

--- a/spec/requests/api/v1/merchants/show_spec.rb
+++ b/spec/requests/api/v1/merchants/show_spec.rb
@@ -1,27 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe 'Merchant Show endpoint' do
-  before :each do
-    merchant = create(:merchant)
+  context 'when a valid id is given' do
+    before :each do
+      merchant = create(:merchant)
 
-    get "/api/v1/merchants/#{merchant.id}"
+      get "/api/v1/merchants/#{merchant.id}"
 
-    full_response = JSON.parse(response.body, symbolize_names: true)
+      full_response = JSON.parse(response.body, symbolize_names: true)
 
-    @merchant = full_response[:data]
+      @merchant = full_response[:data]
+    end
+
+    it 'returns a JSON object with data on the merchant' do
+      expect(@merchant).to have_key :id
+      expect(@merchant[:id]).to be_a String
+
+      expect(@merchant).to have_key :type
+      expect(@merchant[:type]).to eq('merchant')
+
+      expect(@merchant).to have_key :attributes
+      expect(@merchant[:attributes]).to be_a Hash
+
+      expect(@merchant[:attributes]).to have_key :name
+      expect(@merchant[:attributes][:name]).to be_a String
+    end
   end
 
-  it 'returns a JSON object with data on the merchant' do
-    expect(@merchant).to have_key :id
-    expect(@merchant[:id]).to be_a String
+  context 'when an invalid id is given' do
+    before :each do
+      @merchant = create(:merchant)
+      get "/api/v1/merchants/#{@merchant.id - 1}"
+    end
 
-    expect(@merchant).to have_key :type
-    expect(@merchant[:type]).to eq('merchant')
+    it 'returns status code 404 if the :id is not found' do
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(404)
+    end
 
-    expect(@merchant).to have_key :attributes
-    expect(@merchant[:attributes]).to be_a Hash
+    it 'returns an error instead of a data object' do
+      response_body = JSON.parse(response.body, symbolize_names: true)
 
-    expect(@merchant[:attributes]).to have_key :name
-    expect(@merchant[:attributes][:name]).to be_a String
+      expect(response_body).to have_key :message
+      expect(response_body[:message]).to eq('your query could not be completed')
+      
+      expect(response_body).to have_key :errors
+      expect(response_body[:errors]).to be_a Array
+      expect(response_body[:errors]).to be_all String
+      expect(response_body[:errors][0]).to eq("no merchant found with an ID of #{@merchant.id - 1}")
+    end
   end
 end


### PR DESCRIPTION
Added a `rescue_from` statement to the MerchantsController which customizes an error response rather than throwing an `ActiveRecord::RecordNotFound` error. 

Moved some logic from the 2 different error serializers into a parent class called `ApplicationErrorSerializer` - 
  - both `ItemErrorSerializer` and `MerchantErrorSerializer` inherit from `ApplicationErrorSerializer`.