### PR TITLE
Item show sad path

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ItemsController < ApplicationController
   before_action :get_item, only: [:show]
+  rescue_from ::ActiveRecord::RecordNotFound, with: :item_not_found
   
   def index
     render json: ItemSerializer.items_index(Item.all)
@@ -27,5 +28,9 @@ class Api::V1::ItemsController < ApplicationController
 
   def item_params
     params.permit(:name, :description, :unit_price, :merchant_id)
+  end
+
+  def item_not_found
+    render json: ItemErrorSerializer.no_item(params[:id]), status: 404
   end
 end

--- a/app/serializers/api/v1/items_controller/item_error_serializer.rb
+++ b/app/serializers/api/v1/items_controller/item_error_serializer.rb
@@ -2,4 +2,8 @@ class Api::V1::ItemsController::ItemErrorSerializer < Api::V1::ApplicationErrorS
   def self.creation_errors(item)
     base_error_with(item.errors.full_messages)
   end
+
+  def self.no_item(id)
+    base_error_with(["no item found with an ID of #{id}"])
+  end
 end

--- a/spec/requests/api/v1/items/show_spec.rb
+++ b/spec/requests/api/v1/items/show_spec.rb
@@ -1,38 +1,66 @@
 require 'rails_helper'
 
 RSpec.describe 'Items Show Endpoint' do
-  before :each do
-    merchant = create(:merchant) do |merchant|
-      create(:item, merchant: merchant)
+  context 'when a valid id is given' do
+    before :each do
+      merchant = create(:merchant) do |merchant|
+        create(:item, merchant: merchant)
+      end
+
+      get "/api/v1/items/#{merchant.items.first.id}"
+
+      full_response = JSON.parse(response.body, symbolize_names: true)
+
+      @item = full_response[:data]
     end
 
-    get "/api/v1/items/#{merchant.items.first.id}"
+    it 'returns a JSON hash with data on the item' do
+      expect(@item).to have_key :id
+      expect(@item[:id]).to be_a String
 
-    full_response = JSON.parse(response.body, symbolize_names: true)
+      expect(@item).to have_key :type
+      expect(@item[:type]).to eq('item')
 
-    @item = full_response[:data]
+      expect(@item).to have_key :attributes
+      expect(@item[:attributes]).to be_a Hash
+
+      expect(@item[:attributes]).to have_key :name
+      expect(@item[:attributes][:name]).to be_a String
+
+      expect(@item[:attributes]).to have_key :description
+      expect(@item[:attributes][:description]).to be_a String
+
+      expect(@item[:attributes]).to have_key :unit_price
+      expect(@item[:attributes][:unit_price]).to be_a Float
+
+      expect(@item[:attributes]).to have_key :merchant_id
+      expect(@item[:attributes][:merchant_id]).to be_a Integer
+    end
   end
 
-  it 'returns a JSON hash with data on the item' do
-    expect(@item).to have_key :id
-    expect(@item[:id]).to be_a String
+  context 'when an invalid id is given' do
+    before :each do
+      merchant = create(:merchant)
+      @item = create(:item, merchant: merchant)
 
-    expect(@item).to have_key :type
-    expect(@item[:type]).to eq('item')
+      get "/api/v1/items/#{@item.id - 1}"
+    end
 
-    expect(@item).to have_key :attributes
-    expect(@item[:attributes]).to be_a Hash
+    it 'returns status code 404' do
+      expect(response).to_not be_successful
+      expect(response).to have_http_status(404)
+    end
 
-    expect(@item[:attributes]).to have_key :name
-    expect(@item[:attributes][:name]).to be_a String
+    it 'returns an error instead of a data object' do
+      response_body = JSON.parse(response.body, symbolize_names: true)
 
-    expect(@item[:attributes]).to have_key :description
-    expect(@item[:attributes][:description]).to be_a String
+      expect(response_body).to have_key :message
+      expect(response_body[:message]).to eq('your query could not be completed')
 
-    expect(@item[:attributes]).to have_key :unit_price
-    expect(@item[:attributes][:unit_price]).to be_a Float
-
-    expect(@item[:attributes]).to have_key :merchant_id
-    expect(@item[:attributes][:merchant_id]).to be_a Integer
+      expect(response_body).to have_key :errors
+      expect(response_body[:errors]).to be_a Array
+      expect(response_body[:errors]).to be_all String
+      expect(response_body[:errors][0]).to eq("no item found with an ID of #{@item.id - 1}")
+    end
   end
 end


### PR DESCRIPTION
Used a `rescue` statement in the `ItemsController` to customize the error for the user, rather than having the code throw an `ActiveRecord::RecordNotFound` error.