### PR TITLE
Refactor items search

### DIFF
--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,22 +1,10 @@
 class Api::V1::Items::SearchController < ApplicationController
   def show
-    if (params[:name] && (params[:max_price] || params[:min_price]))
+    item = Item.find_first_by_params(params)
+    
+    if item.nil?
       render json: Api::V1::ItemsController::ItemErrorSerializer.invalid_search, status: 404
-
-    elsif (params[:name] && (!params[:max_price] && !params[:min_price]))
-      item = Item.find_first_by_name(params[:name])
-      render json: Api::V1::ItemsController::ItemSerializer.item_show(item)
-
-    elsif (params[:max_price] && params[:min_price])
-      item = Item.find_first_by_price_range(params[:min_price], params[:max_price]) 
-      render json: Api::V1::ItemsController::ItemSerializer.item_show(item)
-
-    elsif (params[:min_price] && !params[:max_price])
-      item = Item.find_first_by_min_price(params[:min_price])
-      render json: Api::V1::ItemsController::ItemSerializer.item_show(item)
-
-    elsif (!params[:min_price] && params[:max_price])
-      item = Item.find_first_by_max_price(params[:max_price])
+    else
       render json: Api::V1::ItemsController::ItemSerializer.item_show(item)
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,6 +9,23 @@ class Item < ApplicationRecord
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
 
+  def self.find_first_by_params(params)
+    if (params[:name] && (params[:max_price] || params[:min_price]))
+      nil 
+    elsif (params[:name] && (!params[:max_price] && !params[:min_price]))
+      find_first_by_name(params[:name])
+
+    elsif (params[:max_price] && params[:min_price])
+      find_first_by_price_range(params[:min_price], params[:max_price])
+
+    elsif (params[:min_price] && !params[:max_price])
+      find_first_by_min_price(params[:min_price])
+
+    elsif (!params[:min_price] && params[:max_price])
+      find_first_by_max_price(params[:max_price])
+    end
+  end
+
   def self.find_first_by_name(name)
     validator = name_check(name)
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Item do
     end
   end
 
-  describe 'finding an Item by price' do
+  context 'class methods to find an item by price' do
     before :each do
       merchant = create(:merchant)
       @item_1 = create(:item, name: 'Turing Handbook', unit_price: 50.50, merchant: merchant)
@@ -62,6 +62,38 @@ RSpec.describe Item do
 
     it '.find_first_by_price_range(min, max) finds all items that match, sorts slphabeticallyby name, and returns the first' do
       expect(Item.find_first_by_price_range(60, 80)).to eq(@item_4)
+    end
+
+    describe '.find_first_by_params(params)' do
+      it 'you can not send name with price in query params' do
+        params = { name: 'ring', min_price: 50 }
+
+        expect(Item.find_first_by_params(params)).to be_falsey
+      end
+
+      it 'returns .find_first_by_name(name) if params only has name' do
+        params = { name: 'ring' } 
+
+        expect(Item.find_first_by_params(params)).to eq(Item.find_first_by_name('ring'))
+      end
+
+      it 'returns .find_first_by_max_price(price) if just max price is given' do
+        params = { max_price: 70 } 
+
+        expect(Item.find_first_by_params(params)).to eq(Item.find_first_by_max_price(70))
+      end
+
+      it 'returns .find_first_by_min_price(price) if just min price is given' do
+        params = { min_price: 50 } 
+
+        expect(Item.find_first_by_params(params)).to eq(Item.find_first_by_min_price(50))
+      end
+
+      it 'returns .find_first_by_price_range(range) if both min and max price are given' do
+        params = { min_price: 60, max_price: 80 } 
+
+        expect(Item.find_first_by_params(params)).to eq(Item.find_first_by_price_range(60, 80))
+      end
     end
   end
 end

--- a/spec/requests/api/v1/items/search/price_show_spec.rb
+++ b/spec/requests/api/v1/items/search/price_show_spec.rb
@@ -112,12 +112,15 @@ RSpec.describe 'Endpoint to find an item by price' do
 
       get '/api/v1/items/find', params: search_params
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       full_response = JSON.parse(response.body, symbolize_names: true)
 
-      expect(full_response).to have_key :data
-      expect(full_response[:data]).to be_a Hash
-      expect(full_response[:data]).to be_empty
+      expect(full_response).to have_key :message
+      expect(full_response[:message]).to eq 'your query could not be completed'
+
+      expect(full_response).to have_key :errors
+      expect(full_response[:errors]).to be_an Array
+      expect(full_response[:errors]).to include 'you can not search for both name and price' 
     end
   end
 

--- a/spec/requests/api/v1/items/search/show_spec.rb
+++ b/spec/requests/api/v1/items/search/show_spec.rb
@@ -54,17 +54,20 @@ RSpec.describe 'Endpoint to Find a single item by name' do
   end
 
   context 'when a record is not found' do
-    it 'returns an empty data object' do
+    it 'returns an error message' do
       search_params = { name: 'NOMATCHPLEASE' }
 
       get '/api/v1/items/find', params: search_params
 
-      expect(response).to be_successful
+      expect(response).to_not be_successful
       full_response = JSON.parse(response.body, symbolize_names: true)
 
-      expect(full_response).to have_key :data
-      expect(full_response[:data]).to be_a Hash
-      expect(full_response[:data]).to be_empty
+      expect(full_response).to have_key :message
+      expect(full_response[:message]).to eq 'your query could not be completed'
+
+      expect(full_response).to have_key :errors
+      expect(full_response[:errors]).to be_an Array
+      expect(full_response[:errors]).to include 'you can not search for both name and price'
     end
   end
 end

--- a/spec/requests/api/v1/merchants/index_spec.rb
+++ b/spec/requests/api/v1/merchants/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'The Merchant Index endpoint' do
     get '/api/v1/merchants'
 
     @full_response = JSON.parse(response.body, symbolize_names: true)
- 
+
     @merchants = @full_response[:data]
   end
 
@@ -29,6 +29,10 @@ RSpec.describe 'The Merchant Index endpoint' do
 
       expect(merchant[:attributes]).to have_key :name
       expect(merchant[:attributes][:name]).to be_a String
+
+      expect(merchant[:attributes]).to_not have_key :created_at
+      expect(merchant[:attributes]).to_not have_key :updated_at
+      # test the serializer is filtering unwanted attributes (created_at, updated_at)
     end
   end
 


### PR DESCRIPTION
- Refactored the `Items::Search` controller to instead use the `Item` to validate params.
- When directed to `Items::Search#Show' action, the controller calls `Item.find_first_by_params(params)` to validate params and fetch an Item
- `Item.find_first_by_params(params)` first checks that `name` and `price` are not in params, then redirects to the appropriate class method based on what query params were sent